### PR TITLE
Select final time step in RNN output

### DIFF
--- a/fflows/models/sequential.py
+++ b/fflows/models/sequential.py
@@ -93,9 +93,7 @@ class RNN(nn.Module):
             r_out, h_n = self.rnn(x.reshape((-1, x.shape[1], 1)), None)
 
         # choose r_out at the last time step
-        out = self.out(r_out[:, -1, :])
-
-        return out.view(-1, x.shape[1])  # .transpose(2, 1)
+        return self.out(r_out[:, -1, :])
 
 
 class RNNmodel(nn.Module):

--- a/fflows/models/sequential.py
+++ b/fflows/models/sequential.py
@@ -93,7 +93,7 @@ class RNN(nn.Module):
             r_out, h_n = self.rnn(x.reshape((-1, x.shape[1], 1)), None)
 
         # choose r_out at the last time step
-        out = self.out(r_out[:, :, :])
+        out = self.out(r_out[:, -1, :])
 
         return out.view(-1, x.shape[1])  # .transpose(2, 1)
 


### PR DESCRIPTION
Changed `r_out[:, :, :]` (selects everything, i.e. does nothing) to `r_out[:, -1, :]` to select the last time step.

## Description

Was experimenting with changing `sig_net` and `mu_net` to be RNN-based, and noticed that the final time step was not being used as the output of the RNN, but rather all time steps were.

Unsure if this also need to change in the `RNNmodel` class.

Still a draft as untested.

## Affected Dependencies
N/A

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/vanderschaarlab/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/vanderschaarlab/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [van der Schaar Lab Styleguide](https://github.com/vanderschaarlab/.github/blob/main/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/vanderschaarlab/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
